### PR TITLE
Incremented the maximal value for keyboard layout ID.

### DIFF
--- a/app/scripts/onlyKey/OnlyKeyComm.js
+++ b/app/scripts/onlyKey/OnlyKeyComm.js
@@ -2180,7 +2180,7 @@ var OnlyKeyHID = function (onlyKeyConfigWizard) {
       kbdLayout = 1;
     }
 
-    kbdLayout = Math.min(kbdLayout, 25);
+    kbdLayout = Math.min(kbdLayout, 26);
 
     myOnlyKey.setKBDLayout(kbdLayout, function (err) {
       myOnlyKey.setLastMessage('received', 'Keyboard Layout set successfully');


### PR DESCRIPTION
This was neccessary because of the new Hungarian keyboard (no. 0x1A) layout couldn't be enabled from the app.