### PR TITLE
Use ISO format for backup filename timestamp

### DIFF
--- a/app/scripts/onlyKey/OnlyKeyComm.js
+++ b/app/scripts/onlyKey/OnlyKeyComm.js
@@ -2040,25 +2040,7 @@ function saveBackupFile(e) {
   var backupData = ui.backupForm.backupData.value.trim();
   if (backupData) {
     d = new Date();
-    dMonth = d.getMonth() + 1;
-    dDate = d.getDate();
-    dYear = d.getFullYear();
-    dHour = d.getHours() + 1 < 12 ? d.getHours() : d.getHours() - 12;
-    dMinutes = (d.getMinutes() < 10 ? "0" : "") + d.getMinutes();
-    dM = d.getHours() + 1 < 12 ? "AM" : "PM";
-    df =
-      dMonth +
-      "-" +
-      dDate +
-      "-" +
-      dYear +
-      "-" +
-      dHour +
-      "-" +
-      dMinutes +
-      "-" +
-      dM;
-    var filename = "onlykey-backup-" + df + ".txt";
+    var filename = "onlykey-backup-" + d.toISOString() + ".txt";
     var blob = new Blob([backupData], {
       type: "text/plain;charset=utf-8",
     });

--- a/app/scripts/onlyKey/OnlyKeyComm.js
+++ b/app/scripts/onlyKey/OnlyKeyComm.js
@@ -2040,7 +2040,8 @@ function saveBackupFile(e) {
   var backupData = ui.backupForm.backupData.value.trim();
   if (backupData) {
     d = new Date();
-    var filename = "onlykey-backup-" + d.toISOString() + ".txt";
+    Date.prototype.__proto__.format = require("es5-ext/date/#/format");
+    var filename = "onlykey-backup-" + d.format("%Y-%m-%dT%H-%M-%S") + ".txt";
     var blob = new Blob([backupData], {
       type: "text/plain;charset=utf-8",
     });


### PR DESCRIPTION
Suggested fix for #158. Instead of:

```
onlykey-backup-MM-D-YYYY-H-M-[AM/PM].txt
```
Use [ISO format](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) date for nicer ordering in file managers:

```
onlykey-backup-YYYY-MM-DDTHH:mm:ss.sssZ.txt
```

Example:

```
onlykey-backup-2011-10-05T14:48:00.000Z
```