### PR TITLE
AutoLaunch fixes

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -118,6 +118,7 @@ if (typeof nw == 'undefined') {
 
     if (osx) {
         autoLaunchOptions.path = appPath;
+        autoLaunchOptions.isHidden = false;
     }
 
     const autoLaunch = new AutoLaunch(autoLaunchOptions);

--- a/app/app.js
+++ b/app/app.js
@@ -105,10 +105,19 @@ if (typeof nw == 'undefined') {
     }
 } else {
     const AutoLaunch = require('auto-launch');
-    const autoLaunch = new AutoLaunch({
+    const { os } = require('os');
+    const osx = os.platform() === 'darwin';
+    const autoLaunchOptions = {
         name: 'OnlyKey',
         isHidden: true
-    });
+    };
+
+    if (osx) {
+        // path should use "nwjs Helper", not "nwjs Helper (Renderer)"
+        autoLaunchOptions.path = process.execPath.replace(/ \(Renderer\)/g, '');
+    }
+
+    const autoLaunch = new AutoLaunch(autoLaunchOptions);
 
     // read localStorage setting or default to true if first time running app
     const enableAutoLaunch = localStorage.hasOwnProperty('autoLaunch') ? !!localStorage.autoLaunch : localStorage.autoLaunch = true;

--- a/app/app.js
+++ b/app/app.js
@@ -47,7 +47,7 @@ chrome.app.runtime.onLaunched.addListener(function() {
         outerBounds: { width: 1024, height: 768 }
       });
 });
-
+    
 var onDevicesEnumerated = async function (devices) {
   if (chrome.runtime.lastError) {
     console.error("onDevicesEnumerated ERROR:", chrome.runtime.lastError);
@@ -103,34 +103,26 @@ if (typeof nw == 'undefined') {
 
         chrome.hid.getDevices(deviceInfo, onDevicesEnumerated);
     }
-} else {
+} else if (!localStorage.hasOwnProperty('autoLaunch')) {
+    // default autoLaunch to true if first time running app
     const AutoLaunch = require('auto-launch');
-    const { os } = require('os');
+    const appPath = require('./scripts/non-renderer-app-path');
+    const appName = appPath.includes('nwjs Helper') ? 'OnlyKey-dev' : 'OnlyKey';
+    const userPreferences = require('./scripts/userPreferences.js');
+    const os = require('os');
     const osx = os.platform() === 'darwin';
     const autoLaunchOptions = {
-        name: 'OnlyKey',
+        name: appName,
         isHidden: true
     };
 
     if (osx) {
-        // path should use "nwjs Helper", not "nwjs Helper (Renderer)"
-        autoLaunchOptions.path = process.execPath.replace(/ \(Renderer\)/g, '');
+        autoLaunchOptions.path = appPath;
     }
 
     const autoLaunch = new AutoLaunch(autoLaunchOptions);
-
-    // read localStorage setting or default to true if first time running app
-    const enableAutoLaunch = localStorage.hasOwnProperty('autoLaunch') ? !!localStorage.autoLaunch : localStorage.autoLaunch = true;
-
-    autoLaunch.isEnabled()
-        .then(isEnabled => {
-            if (isEnabled && !enableAutoLaunch) {
-                autoLaunch.disable();
-            } else if(!isEnabled && enableAutoLaunch) {
-                autoLaunch.enable();
-            }
-        })
-        .catch(console.error);
+    autoLaunch.enable();
+    userPreferences.autoLaunch = true;
 }
 
 function setTime(connectionId) {

--- a/app/scripts/non-renderer-app-path.js
+++ b/app/scripts/non-renderer-app-path.js
@@ -1,0 +1,14 @@
+const devApp = 'nwjs Helper.app';
+const prodApp = 'OnlyKey App.app';
+// path should use "nwjs Helper", not "nwjs Helper (Renderer)"
+const tempPath = process.execPath.replace(/ \(Renderer\)/g, '');
+let appPath;
+if (tempPath.includes(prodApp)) {
+  const pathParts = tempPath.split(prodApp);
+  appPath = pathParts[0] + prodApp;
+} else {
+  const pathParts = tempPath.split(devApp);
+  appPath = pathParts[0] + devApp;
+}
+
+module.exports = appPath;

--- a/app/scripts/tray.js
+++ b/app/scripts/tray.js
@@ -76,9 +76,11 @@
 
   const tray = new nw.Tray({
     icon: './images/ok-tray-logo.png',
-    tooltip: 'OnlyKey Configuration App settings',
   });
-
+  
+  // linux tooltip resulted in menu items failing to render sometimes when the app was launched
+  if (!linux) tray.tooltip = 'OnlyKey Configuration App settings';
+  
   settingsMenu.append(autoLaunchMenuItem);
   settingsMenu.append(autoUpdateMenuItem);
   settingsMenu.append(autoUpdateFWMenuItem);

--- a/app/scripts/tray.js
+++ b/app/scripts/tray.js
@@ -1,75 +1,81 @@
-(function () {
+(async function () {
   "use strict";
 
   if (typeof nw == "undefined") return;
 
-  const userPreferences = require("./scripts/userPreferences.js");
+  const userPreferences = require('./scripts/userPreferences.js');
   const settingsMenu = new nw.Menu();
   
-  const os = require("os");
-  const linux = os.platform() === 'linux';
+  const appPath = require('./scripts/non-renderer-app-path');
+  const appName = appPath.includes('nwjs Helper') ? 'OnlyKey-dev' : 'OnlyKey';
+  const os = require('os');
   const osx = os.platform() === 'darwin';
+  const linux = os.platform() === 'linux';
+
+  const AutoLaunch = require("auto-launch");
+  const autoLaunchOptions = {
+      name: appName,
+      isHidden: true
+  };
+
+  if (osx) {
+      autoLaunchOptions.path = appPath;
+  }
+
+  const autoLaunch = new AutoLaunch(autoLaunchOptions);
+  let autoLaunchEnabledInOSAtLaunch;
+  await autoLaunch.isEnabled().then(isEnabled => {
+    autoLaunchEnabledInOSAtLaunch = isEnabled;
+    userPreferences.autoLaunch = isEnabled;
+  });
 
   const autoLaunchMenuItem = new nw.MenuItem({
-    label: "Auto-launch app on system login",
+    label: 'Auto-launch app on system login',
     click: function () {
       userPreferences.autoLaunch = !userPreferences.autoLaunch;
       console.info(`Toggled autoLaunch to ${userPreferences.autoLaunch}`);
-
-      const AutoLaunch = require("auto-launch");
-      const autoLaunchOptions = {
-          name: 'OnlyKey',
-          isHidden: true
-      };
-  
-      if (osx) {
-          // path should use "nwjs Helper", not "nwjs Helper (Renderer)"
-          autoLaunchOptions.path = process.execPath.replace(/ \(Renderer\)/g, '');
-      }
-  
-      const autoLaunch = new AutoLaunch(autoLaunchOptions);
   
       autoLaunch
-      .isEnabled()
-      .then((isEnabled) => {
-        if (isEnabled && !userPreferences.autoLaunch) {
-          autoLaunch.disable();
-        } else if (!isEnabled && userPreferences.autoLaunch) {
-          autoLaunch.enable();
-        }
-        refreshMenuItem(autoLaunchMenuItem, 0);
-      })
-      .catch(console.error);
+        .isEnabled()
+        .then((isEnabled) => {
+          if (isEnabled && !userPreferences.autoLaunch) {
+            autoLaunch.disable();
+          } else if (!isEnabled && userPreferences.autoLaunch) {
+            autoLaunch.enable();
+          }
+          refreshMenuItem(autoLaunchMenuItem, 0);
+        })
+        .catch(console.error);
     },
-    type: "checkbox",
-    checked: userPreferences.autoLaunch,
+    type: 'checkbox',
+    checked: !!autoLaunchEnabledInOSAtLaunch,
   });
 
   const autoUpdateMenuItem = new nw.MenuItem({
-    label: "Automatically check for app updates",
+    label: 'Automatically check for app updates',
     click: function () {
       userPreferences.autoUpdate = !userPreferences.autoUpdate;
       console.info(`Toggled autoUpdate to ${userPreferences.autoUpdate}`);
       refreshMenuItem(autoUpdateMenuItem, 1);
     },
-    type: "checkbox",
+    type: 'checkbox',
     checked: userPreferences.autoUpdate,
   });
 
   const autoUpdateFWMenuItem = new nw.MenuItem({
-    label: "Automatically check for firmware updates",
+    label: 'Automatically check for firmware updates',
     click: function () {
       userPreferences.autoUpdateFW = !userPreferences.autoUpdateFW;
       console.info(`Toggled autoUpdateFW to ${userPreferences.autoUpdateFW}`);
       refreshMenuItem(autoUpdateFWMenuItem, 2);
     },
-    type: "checkbox",
+    type: 'checkbox',
     checked: userPreferences.autoUpdateFW,
   });
 
   const tray = new nw.Tray({
-    icon: "./images/ok-tray-logo.png",
-    tooltip: "OnlyKey Configuration App settings",
+    icon: './images/ok-tray-logo.png',
+    tooltip: 'OnlyKey Configuration App settings',
   });
 
   settingsMenu.append(autoLaunchMenuItem);

--- a/app/scripts/tray.js
+++ b/app/scripts/tray.js
@@ -20,6 +20,7 @@
 
   if (osx) {
       autoLaunchOptions.path = appPath;
+      autoLaunchOptions.isHidden = false;
   }
 
   const autoLaunch = new AutoLaunch(autoLaunchOptions);

--- a/app/scripts/tray.js
+++ b/app/scripts/tray.js
@@ -1,60 +1,88 @@
-(function() {
-  'use strict';
+(function () {
+  "use strict";
 
-  if (typeof nw == 'undefined') return;
+  if (typeof nw == "undefined") return;
 
-  const userPreferences = require('./scripts/userPreferences.js');
+  const userPreferences = require("./scripts/userPreferences.js");
   const settingsMenu = new nw.Menu();
+  
+  const os = require("os");
+  const linux = os.platform() === 'linux';
+  const osx = os.platform() === 'darwin';
 
-  settingsMenu.append(new nw.MenuItem({
-      label: 'Auto-launch app on system login',
-      click: function() {
-          userPreferences.autoLaunch = !userPreferences.autoLaunch;
-          console.info(`Toggled autoLaunch to ${userPreferences.autoLaunch}`);
+  const autoLaunchMenuItem = new nw.MenuItem({
+    label: "Auto-launch app on system login",
+    click: function () {
+      userPreferences.autoLaunch = !userPreferences.autoLaunch;
+      console.info(`Toggled autoLaunch to ${userPreferences.autoLaunch}`);
 
-          const AutoLaunch = require('auto-launch');
-          const autoLaunch = new AutoLaunch({
-              name: 'OnlyKey',
-              isHidden: true,
-          });
+      const AutoLaunch = require("auto-launch");
+      const autoLaunchOptions = {
+          name: 'OnlyKey',
+          isHidden: true
+      };
+  
+      if (osx) {
+          // path should use "nwjs Helper", not "nwjs Helper (Renderer)"
+          autoLaunchOptions.path = process.execPath.replace(/ \(Renderer\)/g, '');
+      }
+  
+      const autoLaunch = new AutoLaunch(autoLaunchOptions);
+  
+      autoLaunch
+      .isEnabled()
+      .then((isEnabled) => {
+        if (isEnabled && !userPreferences.autoLaunch) {
+          autoLaunch.disable();
+        } else if (!isEnabled && userPreferences.autoLaunch) {
+          autoLaunch.enable();
+        }
+        refreshMenuItem(autoLaunchMenuItem, 0);
+      })
+      .catch(console.error);
+    },
+    type: "checkbox",
+    checked: userPreferences.autoLaunch,
+  });
 
-          autoLaunch.isEnabled()
-              .then(isEnabled => {
-                  if (isEnabled && !userPreferences.autoLaunch) {
-                      autoLaunch.disable();
-                  } else if(!isEnabled && userPreferences.autoLaunch) {
-                      autoLaunch.enable();
-                  }
-              })
-              .catch(console.error);
-      },
-      type: 'checkbox',
-      checked: userPreferences.autoLaunch,
-  }));
+  const autoUpdateMenuItem = new nw.MenuItem({
+    label: "Automatically check for app updates",
+    click: function () {
+      userPreferences.autoUpdate = !userPreferences.autoUpdate;
+      console.info(`Toggled autoUpdate to ${userPreferences.autoUpdate}`);
+      refreshMenuItem(autoUpdateMenuItem, 1);
+    },
+    type: "checkbox",
+    checked: userPreferences.autoUpdate,
+  });
 
-  settingsMenu.append(new nw.MenuItem({
-      label: 'Automatically check for app updates',
-      click: function() {
-          userPreferences.autoUpdate = !userPreferences.autoUpdate;
-          console.info(`Toggled autoUpdate to ${userPreferences.autoUpdate}`);
-      },
-      type: 'checkbox',
-      checked: userPreferences.autoUpdate,
-  }));
-
-  settingsMenu.append(new nw.MenuItem({
-      label: 'Automatically check for firmware updates',
-      click: function() {
-          userPreferences.autoUpdateFW = !userPreferences.autoUpdateFW;
-          console.info(`Toggled autoUpdateFW to ${userPreferences.autoUpdateFW}`);
-      },
-      type: 'checkbox',
-      checked: userPreferences.autoUpdateFW,
-  }));
+  const autoUpdateFWMenuItem = new nw.MenuItem({
+    label: "Automatically check for firmware updates",
+    click: function () {
+      userPreferences.autoUpdateFW = !userPreferences.autoUpdateFW;
+      console.info(`Toggled autoUpdateFW to ${userPreferences.autoUpdateFW}`);
+      refreshMenuItem(autoUpdateFWMenuItem, 2);
+    },
+    type: "checkbox",
+    checked: userPreferences.autoUpdateFW,
+  });
 
   const tray = new nw.Tray({
-    icon: './images/ok-tray-logo.png',
-    menu: settingsMenu,
-    tooltip: 'OnlyKey Configuration App settings'
+    icon: "./images/ok-tray-logo.png",
+    tooltip: "OnlyKey Configuration App settings",
   });
+
+  settingsMenu.append(autoLaunchMenuItem);
+  settingsMenu.append(autoUpdateMenuItem);
+  settingsMenu.append(autoUpdateFWMenuItem);
+  tray.menu = settingsMenu;
+
+  // discovered on linux that the menu item checked state does not live update
+  function refreshMenuItem(menuItem, index) {
+    if (!linux) return;
+
+    settingsMenu.remove(menuItem);
+    settingsMenu.insert(menuItem, index);
+    tray.menu = settingsMenu;
+  }
 })();

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "auto-launch": "^5.0.5",
     "js-sha256": "^0.9.0",
-    "nw": "^0.40.2",
+    "nw": "^0.55.0",
     "nw-autoupdater": "^1.1.8",
     "request": "^2.88.0",
     "sshpk": "^1.16.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "auto-launch": "^5.0.5",
     "js-sha256": "^0.9.0",
-    "nw": "^0.55.0",
+    "nw": "^0.40.2",
     "nw-autoupdater": "^1.1.8",
     "request": "^2.88.0",
     "sshpk": "^1.16.1"

--- a/tasks/release_osx.js
+++ b/tasks/release_osx.js
@@ -47,7 +47,7 @@ const copyBuiltApp = function () {
 
 const prepareOsSpecificThings = function () {
     // Info.plist
-    console.log(`Doing OSX-specific things...`);
+    console.log('Doing OSX-specific things...');
     let info = projectDir.read('resources/osx/Info.plist');
     info = replace(info, {
         productName: manifest.productName,


### PR DESCRIPTION
When the app is launched for the first time (or its local storage is removed) it should set:

- the userPreferences (local storage) to TRUE
- "Auto-launch app on system login" to TRUE in the tray menu
- an OS login item

If the tray menu item is toggled, both local storage and the OS login item should be in the correct state.

If the OS login item is removed (or added) while the app is closed, when the app is launched, the tray menu item and local storage should respect the OS login item state.