### PR TITLE
Use descriptive categories for the Linux launcher

### DIFF
--- a/resources/linux/app.desktop
+++ b/resources/linux/app.desktop
@@ -7,4 +7,4 @@ Comment={{description}}
 Exec=/opt/{{name}}/nw
 Icon=/opt/{{name}}/icon.png
 Terminal=false
-Categories=Application;
+Categories=Settings;Security;


### PR DESCRIPTION
At the moment, the Linux application launcher (`resources/linux/app.desktop`) uses the _Application_ category. Under launchers with category display such as Plasma desktop's Kickoff, this would land under the "Lost & found" section given that "Application" is an unrecognized category.

This PR changes the _Application_ category in favour of:

* The "Settings" category, which is part of the registered main Freedesktop categories ( ref.: https://specifications.freedesktop.org/menu-spec/latest/apa.html#main-category-registry )
* The "Security" category, which is an additional one that can be used alongside "Settings" ( ref.: https://specifications.freedesktop.org/menu-spec/latest/apas02.html )

Tested under Kickoff, this indeed moves the application launcher from "Lost & Found" to "Settings" (which is a bit more descriptive a category).