### PR TITLE
properly identify the HMAC type (==9) on 'Advanced' => 'Add Private Key' dialog

### DIFF
--- a/app/scripts/onlyKey/OnlyKeyComm.js
+++ b/app/scripts/onlyKey/OnlyKeyComm.js
@@ -1726,7 +1726,7 @@ function submitEccForm(e) {
 
   var priv_type = "ECC";
 
-  if (type == 0) {
+  if (type == 9) {
     maxKeyLength = 40; // 20 hex pairs
     priv_type = "HMAC";
   }


### PR DESCRIPTION
the HMAC option list value has been changed on commit https://github.com/trustcrypto/OnlyKey-App/commit/ad4b83c7b0aa8e9275c413667cc5b5cbe42f717e but not changed here. this will fix that only 20 hex pairs are required to save the HMAC key.