### PR TITLE
catch error and show linux udev dialog

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -1384,6 +1384,12 @@
       <h1>Please connect your OnlyKey</h1>
     </dialog>
 
+    <dialog id="udev-dialog" class="silver-gradient-bg">
+      <h1>Error connecting</h1>
+      <h3>Do you need a UDEV rule?</h3>
+      <p>See the <u><a class="external" href="https://docs.onlykey.io/linux.html#udev-rule">OnlyKey for Linux docs</a></u> for more info.</p>
+    </dialog>
+
     <dialog id="working-dialog" class="silver-gradient-bg">
       <h1>Working...</h1>
       <h2>Please wait</h2>

--- a/app/scripts/external-links.js
+++ b/app/scripts/external-links.js
@@ -1,4 +1,4 @@
-document.querySelector('#main').addEventListener('click', evt => {
+const handler = evt => {
     const parent = (evt.path && evt.path[1]) || {};
     const href = evt.target && evt.target.href ? evt.target.href : parent.href;
 
@@ -8,4 +8,9 @@ document.querySelector('#main').addEventListener('click', evt => {
         evt.preventDefault && evt.preventDefault();
         evt.stopPropgation && evt.stopPropagation();
     }
-});
+};
+
+[
+    '#main',
+    '#udev-dialog',
+].forEach(sel => document.querySelector(sel).addEventListener('click', handler));


### PR DESCRIPTION
When the app is run in linux without the required udev rule, chrome.hid returns an error. The app will now catch the error and display a dialog box linking to the OnlyKey for Linux documentation.

![image](https://user-images.githubusercontent.com/601129/201018544-7e07040f-a3ce-48df-9de1-80c990f815ea.png)
