### PR TITLE
Resolve unresponsive UI in Linux (Ubuntu 22.04, 22.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "auto-launch": "^5.0.5",
     "js-sha256": "^0.9.0",
-    "nw": "^0.55.0",
-    "nw-autoupdater": "^1.1.8",
+    "nw": "^0.72.0",
+    "nw-autoupdater": "^1.1.11",
     "request": "^2.88.0",
     "sshpk": "^1.16.1"
   },


### PR DESCRIPTION
Updating the nw.js package to 0.72.0 resolves the UI hang, at least when running using 'npm start'. I have not yet encountered any issues; however 'npm test' was broken by a past commit - the chromedriver is only included in the SDK variant of NWJS.

I was able to update the firmware and start the initial setup without issue.

This should resolve issue #198 (Problems with UI not responding)