### PR TITLE
Feat/major package updates

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -820,7 +820,7 @@
         </p>
         <hr />
         <div class="flex-container">
-          <div class="flex-item">
+          <div class="flex-item" style="max-width: 40%">
             <p>
               Need an OpenPGP key? Follow our guide
               <a
@@ -831,7 +831,7 @@
               for generating an OpenPGP key with Keybase.
             </p>
             <p>
-              Before loading a key, <span class="strong">you must first put your OnlyKey into config mode</span>.
+              Before loading a key, <span class="critical-text">you must first put your OnlyKey into config mode</span>.
               <br/><br/>
               To do this
               <span class="device-specific ok-classic">hold down button #6 on your OnlyKey for 5+ seconds and release.</span>
@@ -839,7 +839,7 @@
               The light will turn off.
               <span class="device-specific ok-duo">If a PIN was previously set, re-enter the PIN to enter config mode.</span>
               You will notice the OnlyKey flashes red in config mode.
-    </p>
+            </p>
           </div>
           <div class="flex-item">
             <form id="rsaForm" name="rsaForm" class="auth-form">

--- a/app/scripts/external-links.js
+++ b/app/scripts/external-links.js
@@ -1,9 +1,12 @@
-document.querySelector('#main').addEventListener('click', evt => {
-    const parent = (evt.path && evt.path[1]) || {};
-    const href = evt.target && evt.target.href ? evt.target.href : parent.href;
+const openMethod = typeof nw === 'undefined' ? window.open : nw.Shell.openExternal;
 
-    if ((evt.target !== evt.currentTarget) && (!!href && (evt.target.classList.contains('external') || parent.classList.contains('external')))) {
-        const openMethod = typeof nw === 'undefined' ? window.open : nw.Shell.openExternal;
+// Formerly checked for 'external' in classList. Now fires for all https:// links.
+document.querySelector('#main').addEventListener('click', evt => {
+    let href = evt.target && evt.target.href;
+    if (!href) href = evt.target && evt.target.offsetParent && evt.target.offsetParent.href;
+    if (!href) href = evt.path && evt.path[1] && evt.path[1].href;
+
+    if (!!href && href.indexOf('https://') == 0) {
         openMethod(href);
         evt.preventDefault && evt.preventDefault();
         evt.stopPropgation && evt.stopPropagation();

--- a/app/scripts/non-renderer-app-path.js
+++ b/app/scripts/non-renderer-app-path.js
@@ -1,6 +1,7 @@
 const devApp = 'nwjs Helper.app';
 const prodApp = 'OnlyKey App.app';
 // path should use "nwjs Helper", not "nwjs Helper (Renderer)"
+console.log({ location: 'non-renderer-app-path.js', process_execPath: process.execPath })
 const tempPath = process.execPath.replace(/ \(Renderer\)/g, '');
 let appPath;
 if (tempPath.includes(prodApp)) {

--- a/app/scripts/onlyKey/OnlyKeyComm.js
+++ b/app/scripts/onlyKey/OnlyKeyComm.js
@@ -2184,12 +2184,12 @@ function checkForNewFW(checkForNewFW, fwUpdateSupport, version) {
       fwchecked = true;
       if (checkForNewFW == true && fwUpdateSupport == true) {
         //fw checking enabled and firmware version supports app updates
-        var r = request.get(
+        console.info("Checking for new firmware");
+        request.get(
           "https://github.com/trustcrypto/OnlyKey-Firmware/releases/latest",
           function (err, res, body) {
             if (err) return reject(err);
 
-            console.log(r.uri.href);
             console.log(this.uri.href);
             //var testupgradeurl = 'https://github.com/trustcrypto/OnlyKey-Firmware/releases/tag/v2.1.0-prod'
             //var latestver = testupgradeurl.split("/tag/v"); //end of redirected URL is the version

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "OnlyKey Configuration",
   "manifest_version": 2,
-  "version": "5.3.6",
-  "version_name": "5.3.6",
+  "version": "5.5.0",
+  "version_name": "5.5.0",
   "minimum_chrome_version": "45.0.2439.3",
   "app": {
     "background": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "OnlyKey",
   "productName": "OnlyKey App",
-  "version": "5.3.6",
-  "version_name": "5.3.6",
+  "version": "5.5.0",
+  "version_name": "5.5.0",
   "description": "Setup and configure OnlyKey",
   "main": "app.js",
   "scripts": {
@@ -18,28 +18,28 @@
   "dependencies": {
     "auto-launch": "^5.0.5",
     "js-sha256": "^0.9.0",
-    "nw": "^0.55.0",
-    "nw-autoupdater": "^1.1.8",
-    "request": "^2.88.0",
-    "sshpk": "^1.16.1"
+    "nw": "^0.71.1",
+    "nw-autoupdater": "^1.1.11",
+    "request": "^2.88.2",
+    "sshpk": "^1.17.0"
   },
   "devDependencies": {
-    "chai": "^4.2.0",
+    "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^6.4.0",
-    "fs-jetpack": "^4.1.0",
+    "eslint": "^8.33.0",
+    "fs-jetpack": "^5.1.0",
     "gulp": "^4.0.2",
-    "gulp-sourcemaps": "^2.6.4",
-    "json": "^10.0.0",
-    "mocha": "^8.2.0",
+    "gulp-sourcemaps": "^3.0.0",
+    "json": "^11.0.0",
+    "mocha": "^10.2.0",
     "nw-dev": "^3.0.1",
     "q": "^1.5.1",
-    "selenium-webdriver": "^3.6.0",
-    "tree-kill": "^1.2.1",
-    "yargs": "^16.1.0"
+    "selenium-webdriver": "^4.8.0",
+    "tree-kill": "^1.2.2",
+    "yargs": "^17.6.2"
   },
   "optionalDependencies": {
-    "appdmg": "^0.6.0"
+    "appdmg": "^0.6.4"
   },
   "repository": {
     "type": "git",
@@ -57,7 +57,7 @@
   "author": "CryptoTrust <admin@crp.to>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/trustcrypto/OnlyKey-App/issues"
+    "url": "https://onlykey.discourse.group/"
   },
   "homepage": "https://github.com/trustcrypto/OnlyKey-App#readme",
   "window": {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,15 @@
   "main": "app.js",
   "scripts": {
     "build": "./node_modules/.bin/gulp build",
+    "build_win": ".\\node_modules\\.bin\\gulp build",
     "prerelease": "rm -rf ./node_modules/* && npm install --production && rm -rf ./release_node_modules && mkdir release_node_modules && cd release_node_modules && mkdir node_modules && cd .. && cp -R ./node_modules/* ./release_node_modules/node_modules && npm install && npm run build -- --env=production",
+    "prerelease_win": "rm -rf ./node_modules/* && npm install --production && rm -rf ./release_node_modules && mkdir release_node_modules && cd release_node_modules && mkdir node_modules && cd .. && cp -R ./node_modules/* ./release_node_modules/node_modules && npm install && npm run build_win -- --env=production",
     "release": "./node_modules/.bin/gulp release --env=production",
+    "release_win": ".\\node_modules\\.bin\\gulp release --env=production",
     "start": "node ./tasks/start",
     "pretest": "npm run-script build",
     "test": "mocha",
+    "testgulp": ".\\node_modules\\.bin\\gulp -v",
     "prechrome": "./node_modules/.bin/gulp build --env=chrome",
     "chrome": "echo 'Please run something like:'; echo \"chrome --load-and-launch-app=$(pwd)/build\""
   },

--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1,19 +1,19 @@
 {
   "name": "OnlyKey",
   "productName": "OnlyKey App",
-  "version": "5.2.0",
+  "version": "5.5.0",
   "packages": {
     "linux64": {
-      "url": "https://s3.amazonaws.com/onlykey/apps/desktop/releases/latest/OnlyKey_5.2.0_amd64.deb",
-      "size": 64000000
+      "url": "https://s3.amazonaws.com/onlykey/apps/desktop/releases/latest/OnlyKey_5.5.0_amd64.deb",
+      "size": 105000000
     },
     "win64": {
-      "url": "https://s3.amazonaws.com/onlykey/apps/desktop/releases/latest/OnlyKey_5.2.0.exe",
-      "size": 67000000
+      "url": "https://s3.amazonaws.com/onlykey/apps/desktop/releases/latest/OnlyKey_5.5.0.exe",
+      "size": 95000000
     },
     "mac64": {
-      "url": "https://s3.amazonaws.com/onlykey/apps/desktop/releases/latest/OnlyKey_5.2.0.dmg",
-      "size": 105000000
+      "url": "https://s3.amazonaws.com/onlykey/apps/desktop/releases/latest/OnlyKey_5.5.0.dmg",
+      "size": 134000000
     }
   },
   "description": "OnlyKey Configuration App"


### PR DESCRIPTION
This release fixes issues #198, #208, #209, and possibly others. All dependencies were updated to available major recent versions.

Note that the auto-start feature will now launch the app in standard mode instead of trying to launch it hidden at login.

WINDOWS-specific build scripts (build_win, prerelease_win, and release_win) have also been added due to issues with filename and path syntax.