### PR TITLE
Clipboard-free password generator, courtesy of JasonJShuler

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -1459,6 +1459,171 @@
       <div id="selectPrivateKeyError" class="form-error"></div>
     </dialog>
 
+    <dialog id="password-generator-dialog">
+      <h2>Strong Random Password Generator</h2>
+      <p>Generate complex, random password without the risk of a clipboard leak.<br/>
+      Make any necessary modifications before applying.</p>
+      <form name="password-generator-form" id="password-generator-form">
+        <table>
+          <tr class="universal-option">
+            <td colspan="2">
+              <input
+                type="text"
+                id="txtPassGen"
+                name="txtPassGen"
+                value=""
+                maxlength="56"
+                style="width: 100%;"
+              />
+            </td>
+          </tr>
+          <tr class="universal-option">
+            <td>
+              <label>
+                <input
+                  type="number"
+                  id="numPassGenLen"
+                  name="numPassGenLen"
+                  value="48"
+                  min="6"
+                  max="56"
+                />
+              Length (6-56)
+              </label> 
+            </td>
+            <td>
+              <input
+                type="button"
+                id="btnPassGen"
+                name="btnPassGen"
+                value="Generate New Password"
+              />
+            </td>
+          </tr>
+          <tr class="universal-option">
+            <td colspan="2">
+              <label>
+                <input
+                  type="checkbox"
+                  id="chkPassGenUpper"
+                  name="chkPassGenUpper"
+                  checked="checked"
+                />
+                Uppercase A-Z
+              </label>
+            </td>
+          </tr>
+          <tr class="universal-option">
+            <td colspan="2">
+              <label>
+                <input
+                  type="checkbox"
+                  id="chkPassGenLower"
+                  name="chkPassGenLower"
+                  checked="checked"
+                />
+                Lowercase a-z
+              </label>
+            </td>
+          </tr>
+          <tr class="universal-option">
+            <td colspan="2">
+              <label>
+                <input
+                  type="checkbox"
+                  id="chkPassGenDigits"
+                  name="chkPassGenDigits"
+                  checked="checked"
+                />
+                Digits 0-9
+              </label>
+            </td>
+          </tr>
+          <tr class="universal-option">
+            <td colspan="2">
+              <label>
+                <input
+                  type="checkbox"
+                  id="chkPassGenSpecial"
+                  name="chkPassGenSpecial"
+                  checked="checked"
+                />
+                Special ~!@#$%^&amp;*+=-_
+              </label>
+            </td>
+          </tr>
+          <tr class="universal-option">
+            <td colspan="2">
+              <label>
+                <input
+                  type="checkbox"
+                  id="chkPassGenPunct"
+                  name="chkPassGenPunct"
+                  checked="checked"
+                />
+                Punctuation &quot;&apos;;:,.?
+              </label>
+            </td>
+          </tr>
+          <tr class="universal-option">
+            <td colspan="2">
+              <label>
+                <input
+                  type="checkbox"
+                  id="chkPassGenBraces"
+                  name="chkPassGenBraces"
+                  checked="checked"
+                />
+                Braces (){}[]&lt;&gt;
+              </label>
+            </td>
+          </tr>
+          <tr class="universal-option">
+            <td colspan="2">
+              <label>
+                <input
+                  type="checkbox"
+                  id="chkPassGenSpace"
+                  name="chkPassGenSpace"
+                />
+                Space
+              </label>
+            </td>
+          </tr>
+          <tr class="universal-option">
+            <td colspan="2">
+              <label>
+                <input
+                  type="text"
+                  id="txtPassGenOmit"
+                  name="txtPassGenOmit"
+                  value=""
+                />
+                Disallowed character list
+              </label>
+            </td>
+          </tr>
+          <tr class="universal-option">
+            <td>
+              <input
+                type="button"
+                id="passGenCancel"
+                name="passGenCancel"
+                value="Cancel"
+              />
+            </td>
+            <td>
+              <input
+                type="button"
+                id="passGenSubmit"
+                name="passGenSubmit"
+                value="Use Password"
+              />
+            </td>
+          </tr>
+        </table>
+      </form>
+    </dialog>
     <dialog id="slot-config-dialog" data-mode="basic" class="silver-gradient-bg">
       <div id="slot-config-top-links">
         <a href="" class="slot-config-close" title="Close">close &#9746;</a>
@@ -1635,6 +1800,14 @@
                 name="txtPassword"
                 value=""
                 maxlength="56"
+              />
+            </td>
+            <td>
+              <input
+                type="button"
+                id="btnLaunchPassGen"
+                name="btnLaunchPassGen"
+                value="Gen"
               />
             </td>
           </tr>

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "OnlyKey Configuration",
   "manifest_version": 2,
-  "version": "5.5.0",
-  "version_name": "5.5.0",
+  "version": "5.6.0",
+  "version_name": "5.6.0",
   "minimum_chrome_version": "45.0.2439.3",
   "app": {
     "background": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "OnlyKey",
   "productName": "OnlyKey App",
-  "version": "5.5.0",
-  "version_name": "5.5.0",
+  "version": "5.6.0",
+  "version_name": "5.6.0",
   "description": "Setup and configure OnlyKey",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Courtesy of @JasonJShuler

Added a cryptographically strong random password generator dialog to the slot editor, launched via a button next to the password field.

### Rationale

The clipboard is a dangerous place for high-security passwords, especially when using remote desktops and virtual machines. Clipboard contents are readily available in cleartext to all local processes - even without admin rights. Furthermore, the clipboard is often synchronized with remote desktop clients and virtual machines - Linux, Windows and Android-based.

Windows 10 and 11 and some Android versions provide clipboard history and cross-device synchronizing... sometimes by default. The security around this clipboard history is dubious and ill-defined.

Considering the extreme convenience of clipboard synchronization, and the use of the clipboard by most password managers, it is unrealistic to expect such facilities to be universally disabled. The security provided by OnlyKey is potentially compromised the moment a password hits the clipboard.

### Resolution

Embed a password generator into the OnlyKey App that doesn't transit the password outside of the OnlyKey-App process. No clipboard, no network - dramatically reduced attack surface.

The generator uses the node.js crypto module's random number generator - which is supposed to be cryptographically secure (unlike math.random). Specifically, it uses crypto.randomInt to avoid modulus biasing.

The user can select from various character classes, specify a length, character exclusions, and review / edit the password before applying it to the slot editor fields (or canceling).


### Screenshots

Slot editor with the "Gen" button next to the password field.

![Slot Editor New Button](https://user-images.githubusercontent.com/29778397/231948979-6188ab33-16c8-487e-b247-7b28cf3fd12e.png)


Generator Dialog
![Generator Dialog](https://user-images.githubusercontent.com/29778397/231949018-925b0959-6865-4f36-9bbe-4853900c8093.png)

