### PR TITLE
release: write per-platform update manifest fragments with sha256 and size

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "audit:release": "npm audit --omit=optional",
     "release": "node scripts/release.mjs",
     "release:skip-audit": "node scripts/release.mjs --skip-audit",
+    "update-manifest": "node scripts/update-manifest.mjs",
     "test": "vitest run",
     "test:desktop": "vitest run --project desktop",
     "test:unit": "vitest run --project ui",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -12,8 +12,11 @@
  * Always stages a runnable app bundle under tmp/release/<name>/ before packaging.
  * On macOS, app.nw is the app payload only (not a nested nwjs.app).
  *
- * After a successful artifact, hashes it and merges `releases/manifest.json`
- * (see `update-manifest.mjs`). Does not upload. Channel env:
+ * After a successful artifact, prints the unsigned path. Hashing for the
+ * update channel happens later, on the SIGNED installer:
+ *   npm run update-manifest -- --artifact releases/OnlyKey_<ver>.exe
+ * (see `update-manifest.mjs`). Signing changes bytes; do not publish a hash
+ * of this unsigned build. Channel env:
  *   ONLYKEY_UPDATE_MANIFEST_URL  — packaged package.json `manifestUrl`
  *                                  (wins over repo `manifest.json`)
  *   ONLYKEY_UPDATE_BASE_URL      — package URL prefix + packaged `updateBaseUrl`
@@ -35,7 +38,6 @@ import {
   DEFAULT_UPDATE_MANIFEST_URL,
   normalizeManifestUrl,
   normalizeUpdateBaseUrl,
-  recordReleaseArtifact,
 } from './update-manifest.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -565,15 +567,10 @@ async function main() {
 
   console.log('Release build complete.');
   if (artifact) {
-    console.log('Artifact:', artifact);
-    recordReleaseArtifact({
-      artifactPath: artifact,
-      version: manifest.version,
-      platform: process.platform,
-      releasesDir,
-      name: manifest.name,
-      productName: manifest.productName,
-    });
+    console.log('Unsigned installer:', artifact);
+    console.log('Sign this file in place (Authenticode / notarize), then hash the signed copy:');
+    console.log(`  npm run update-manifest -- --artifact "${artifact}"`);
+    console.log('Do not upload an unsigned installer or a SHA-256 taken before signing.');
   }
 }
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -11,6 +11,15 @@
  *
  * Always stages a runnable app bundle under tmp/release/<name>/ before packaging.
  * On macOS, app.nw is the app payload only (not a nested nwjs.app).
+ *
+ * After a successful artifact, hashes it and merges `releases/manifest.json`
+ * (see `update-manifest.mjs`). Does not upload. Channel env:
+ *   ONLYKEY_UPDATE_MANIFEST_URL  — packaged package.json `manifestUrl`
+ *                                  (wins over repo `manifest.json`)
+ *   ONLYKEY_UPDATE_BASE_URL      — package URL prefix + packaged `updateBaseUrl`
+ *
+ * Client fetches are fail-closed (`redirect: 'error'`). If a staging GET throws
+ * TypeError, dump `Location`; do not follow HTTP.
  */
 import { execSync, spawn } from 'node:child_process';
 import fs from 'node:fs';
@@ -22,6 +31,12 @@ import {
   mergeUniversalApp,
   officialNwVersion,
 } from './mac-universal.mjs';
+import {
+  DEFAULT_UPDATE_MANIFEST_URL,
+  normalizeManifestUrl,
+  normalizeUpdateBaseUrl,
+  recordReleaseArtifact,
+} from './update-manifest.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..');
@@ -125,16 +140,20 @@ function resolveMakensis() {
   return 'makensis';
 }
 
-function buildProductionPackageJson(source) {
-  let manifestUrl = 'https://s3.amazonaws.com/onlykey-app/releases/latest/manifest.json';
-  try {
-    const updateManifest = JSON.parse(
-      fs.readFileSync(path.join(rootDir, 'manifest.json'), 'utf8')
-    );
-    if (updateManifest.manifestUrl) manifestUrl = updateManifest.manifestUrl;
-  } catch {
-    /* optional */
+export function buildProductionPackageJson(source) {
+  let manifestUrl = process.env.ONLYKEY_UPDATE_MANIFEST_URL;
+  if (!manifestUrl) {
+    try {
+      const updateManifest = JSON.parse(
+        fs.readFileSync(path.join(rootDir, 'manifest.json'), 'utf8')
+      );
+      if (updateManifest.manifestUrl) manifestUrl = updateManifest.manifestUrl;
+    } catch {
+      /* optional */
+    }
   }
+  manifestUrl = normalizeManifestUrl(manifestUrl || DEFAULT_UPDATE_MANIFEST_URL);
+  const updateBaseUrl = normalizeUpdateBaseUrl(process.env.ONLYKEY_UPDATE_BASE_URL);
 
   return {
     name: source.name,
@@ -144,6 +163,7 @@ function buildProductionPackageJson(source) {
     description: source.description,
     main: 'dist/index.html',
     manifestUrl,
+    ...(updateBaseUrl ? { updateBaseUrl } : {}),
     'chromium-args': source['chromium-args'],
     window: {
       ...source.window,
@@ -544,7 +564,17 @@ async function main() {
   }
 
   console.log('Release build complete.');
-  if (artifact) console.log('Artifact:', artifact);
+  if (artifact) {
+    console.log('Artifact:', artifact);
+    recordReleaseArtifact({
+      artifactPath: artifact,
+      version: manifest.version,
+      platform: process.platform,
+      releasesDir,
+      name: manifest.name,
+      productName: manifest.productName,
+    });
+  }
 }
 
 function isMainModule() {

--- a/scripts/update-manifest.mjs
+++ b/scripts/update-manifest.mjs
@@ -1,27 +1,39 @@
 /**
- * Emit the remote app-update manifest after `npm run release`.
+ * Emit the remote app-update manifest from the **signed** installer that will
+ * be uploaded. Authenticode / notarization changes file bytes — hashing the
+ * unsigned `npm run release` output would fail every client SHA-256 check.
  *
- * Each OS build writes `releases/update-manifest.d/<win64|mac64|linux64>.json`
- * and merges whatever fragments share this version into `releases/manifest.json`.
- * A one-platform file is publishable; other OSes get `missing-platform`.
+ *   npm run release
+ *   # sign in place (same filename: OnlyKey_<ver>.exe / .dmg / _amd64.deb)
+ *   npm run update-manifest -- --artifact releases/OnlyKey_5.7.0.exe
  *
- * Env (pack-time, no AWS credentials in this repo):
+ * Writes `releases/update-manifest.d/<win64|mac64|linux64>.json` and merges
+ * same-version fragments into `releases/manifest.json`. A one-platform file is
+ * publishable; other OSes get `missing-platform`.
+ *
+ * Env (no AWS credentials in this repo):
  *   ONLYKEY_UPDATE_BASE_URL       — HTTPS prefix for package URLs
  *                                   (default prod S3 `…/releases/latest`)
  *   ONLYKEY_UPDATE_MANIFEST_URL   — baked into packaged `package.json`
  *                                   (`buildProductionPackageJson` in release.mjs)
  *
- * Upload `manifest.json` + the new artifact(s) the same way 5.6 was published.
- * This script does not upload.
+ * Upload `manifest.json` + the same signed artifact(s) the same way 5.6 was
+ * published. This script does not upload.
  *
+ * Windows/macOS: refuses `NotSigned` unless `--allow-unsigned`.
  * Client fetches use `{ cache: 'no-store', redirect: 'error' }` (fail-closed).
  * If a staging GET throws TypeError, dump the `Location` header; do not follow
  * HTTP. Path-style `s3.amazonaws.com` is not the same host as virtual-hosted
  * `bucket.s3.<region>.amazonaws.com`.
  */
+import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const repoRoot = path.resolve(__dirname, '..');
 
 export const DEFAULT_UPDATE_BASE_URL =
   'https://s3.amazonaws.com/onlykey-app/releases/latest';
@@ -55,6 +67,86 @@ export function platformPackageKey(platform = process.platform) {
   if (platform === 'darwin' || platform === 'osx' || platform === 'mac') return 'mac64';
   if (platform === 'linux') return 'linux64';
   return null;
+}
+
+/** Infer node platform from the installer filename (`OnlyKey_5.7.0.exe` → win32). */
+export function inferPlatformFromArtifact(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.exe') return 'win32';
+  if (ext === '.dmg') return 'darwin';
+  if (ext === '.deb') return 'linux';
+  return null;
+}
+
+export function inspectAuthenticode(filePath) {
+  const ps = [
+    `$s = Get-AuthenticodeSignature -LiteralPath ${JSON.stringify(filePath)}`,
+    '@{ Status = [string]$s.Status; Signer = [string]$s.SignerCertificate.Subject } | ConvertTo-Json -Compress',
+  ].join('; ');
+  const out = execFileSync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', ps],
+    { encoding: 'utf8' },
+  );
+  const parsed = JSON.parse(out.trim() || '{}');
+  return { status: String(parsed.Status || ''), signer: parsed.Signer || '' };
+}
+
+export function inspectCodesign(filePath) {
+  try {
+    execFileSync('codesign', ['--verify', filePath], { encoding: 'utf8', stdio: 'pipe' });
+    return { status: 'Valid', signer: '' };
+  } catch (e) {
+    const err = /** @type {Error & { status?: number, stderr?: string }} */ (e);
+    if (err.status == null && /ENOENT|not found/i.test(err.message)) {
+      throw new Error(
+        'codesign is not available. Hash the notarized DMG on macOS, or pass --allow-unsigned.',
+      );
+    }
+    return { status: 'NotSigned', signer: '' };
+  }
+}
+
+/**
+ * Refuse to hash an installer that is not OS-signed. Signing changes bytes;
+ * an unsigned hash must never be published.
+ *
+ * @param {string} filePath
+ * @param {string} platform
+ * @param {{
+ *   requireSigned?: boolean,
+ *   inspectAuthenticode?: (p: string) => { status: string, signer?: string },
+ *   inspectCodesign?: (p: string) => { status: string, signer?: string },
+ * }} [io]
+ */
+export function assertSignedArtifact(filePath, platform, io = {}) {
+  if (io.requireSigned === false) return { status: 'skipped', signer: '' };
+  const key = platformPackageKey(platform);
+  if (key === 'linux64') return { status: 'skipped', signer: '' };
+
+  if (key === 'win64') {
+    const inspect = io.inspectAuthenticode || inspectAuthenticode;
+    const result = inspect(filePath);
+    if (result.status === 'NotSigned' || result.status === 'HashMismatch' || !result.status) {
+      throw new Error(
+        `Refusing to hash an unsigned Windows installer (${result.status || 'unknown'}). Sign in place with Authenticode, then re-run update-manifest on that same file.`,
+      );
+    }
+    return result;
+  }
+
+  if (key === 'mac64') {
+    const inspect = io.inspectCodesign || inspectCodesign;
+    const result = inspect(filePath);
+    if (result.status !== 'Valid') {
+      throw new Error(
+        `Refusing to hash an unsigned macOS installer (${result.status}). Notarize/sign the DMG, then re-run update-manifest on that same file.`,
+      );
+    }
+    return result;
+  }
+
+  throw new Error(`No update-manifest platform key for ${platform}`);
 }
 
 export function assertSha256(value, label = 'sha256') {
@@ -176,16 +268,24 @@ export function mergeFragments(dir, opts) {
  *   name?: string,
  *   productName?: string,
  *   now?: string,
+ *   requireSigned?: boolean,
+ *   inspectAuthenticode?: (p: string) => { status: string, signer?: string },
+ *   inspectCodesign?: (p: string) => { status: string, signer?: string },
  *   log?: { log: (...args: unknown[]) => void, warn?: (...args: unknown[]) => void },
  * }} opts
  */
 export function recordReleaseArtifact(opts) {
   const log = opts.log || console;
-  const platform = opts.platform || process.platform;
+  const platform = opts.platform || inferPlatformFromArtifact(opts.artifactPath) || process.platform;
   const key = platformPackageKey(platform);
   if (!key) {
     throw new Error(`No update-manifest platform key for ${platform}`);
   }
+  const signature = assertSignedArtifact(opts.artifactPath, platform, {
+    requireSigned: opts.requireSigned,
+    inspectAuthenticode: opts.inspectAuthenticode,
+    inspectCodesign: opts.inspectCodesign,
+  });
   const baseUrl = opts.baseUrl || process.env.ONLYKEY_UPDATE_BASE_URL || DEFAULT_UPDATE_BASE_URL;
   const { sha256, size } = hashFile(opts.artifactPath);
   const fragmentDir = path.join(opts.releasesDir, 'update-manifest.d');
@@ -209,15 +309,105 @@ export function recordReleaseArtifact(opts) {
   const keys = Object.keys(merged.packages);
   log.log(`Wrote update manifest: ${outPath}`);
   log.log(`  ${key}  sha256=${sha256}  size=${size}`);
+  if (signature.status && signature.status !== 'skipped') {
+    log.log(`  signature: ${signature.status}${signature.signer ? `  ${signature.signer}` : ''}`);
+  }
+  log.log('Upload THIS signed file together with manifest.json (same bytes as the hash).');
   log.log(
-    'Upload manifest.json together with the new artifact(s) to the same S3 prefix as 5.6',
+    'Do not upload an unsigned copy or a file signed after this hash was taken.',
   );
   log.log(`  default: s3://onlykey-app/releases/latest/  (${DEFAULT_UPDATE_BASE_URL})`);
-  log.log('This build does not upload. There are no AWS credentials in this repo.');
+  log.log('This script does not upload. There are no AWS credentials in this repo.');
   if (keys.length < PLATFORM_KEYS.length) {
     log.log(
       `This manifest has ${keys.join(', ') || 'no platforms'}. A one-platform manifest is publishable; other OSes get missing-platform (auto-check silent; Check now shows an error).`,
     );
   }
-  return { outPath, manifest: merged, sha256, size, key };
+  return { outPath, manifest: merged, sha256, size, key, signature };
+}
+
+export function parseUpdateManifestArgs(argv) {
+  /** @type {{ artifact?: string, version?: string, platform?: string, releasesDir?: string, allowUnsigned: boolean, help: boolean }} */
+  const out = { allowUnsigned: false, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => {
+      const v = argv[++i];
+      if (!v || v.startsWith('--')) throw new Error(`Missing value for ${a}`);
+      return v;
+    };
+    if (a === '--artifact') out.artifact = next();
+    else if (a === '--version') out.version = next();
+    else if (a === '--platform') out.platform = next();
+    else if (a === '--releases-dir') out.releasesDir = next();
+    else if (a === '--allow-unsigned') out.allowUnsigned = true;
+    else if (a === '--help' || a === '-h') out.help = true;
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return out;
+}
+
+function usage() {
+  return `Usage: node scripts/update-manifest.mjs --artifact <signed-installer>
+
+Hash the SIGNED installer (Authenticode / notarized DMG / shipped .deb) and
+merge releases/manifest.json. Sign in place so the filename stays
+OnlyKey_<ver>.exe / .dmg / _amd64.deb.
+
+  --artifact <path>     signed installer (required)
+  --version <semver>    default: package.json version
+  --platform <id>       win32|darwin|linux (default: from filename)
+  --releases-dir <dir>  default: ./releases
+  --allow-unsigned      skip Authenticode/codesign check (do not publish)
+`;
+}
+
+function readPkg() {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+}
+
+function main(argv = process.argv.slice(2)) {
+  const args = parseUpdateManifestArgs(argv);
+  if (args.help) {
+    console.log(usage());
+    return 0;
+  }
+  if (!args.artifact) {
+    console.error(usage());
+    return 1;
+  }
+  const pkg = readPkg();
+  recordReleaseArtifact({
+    artifactPath: path.resolve(args.artifact),
+    version: args.version || pkg.version,
+    platform: args.platform || inferPlatformFromArtifact(args.artifact) || process.platform,
+    releasesDir: path.resolve(args.releasesDir || path.join(repoRoot, 'releases')),
+    name: pkg.name,
+    productName: pkg.productName,
+    requireSigned: !args.allowUnsigned,
+  });
+  return 0;
+}
+
+function isMainModule() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return (
+      path.normalize(fileURLToPath(import.meta.url)).toLowerCase() ===
+      path.normalize(path.resolve(entry)).toLowerCase()
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  try {
+    const code = main();
+    if (code) process.exit(code);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
 }

--- a/scripts/update-manifest.mjs
+++ b/scripts/update-manifest.mjs
@@ -1,0 +1,223 @@
+/**
+ * Emit the remote app-update manifest after `npm run release`.
+ *
+ * Each OS build writes `releases/update-manifest.d/<win64|mac64|linux64>.json`
+ * and merges whatever fragments share this version into `releases/manifest.json`.
+ * A one-platform file is publishable; other OSes get `missing-platform`.
+ *
+ * Env (pack-time, no AWS credentials in this repo):
+ *   ONLYKEY_UPDATE_BASE_URL       — HTTPS prefix for package URLs
+ *                                   (default prod S3 `…/releases/latest`)
+ *   ONLYKEY_UPDATE_MANIFEST_URL   — baked into packaged `package.json`
+ *                                   (`buildProductionPackageJson` in release.mjs)
+ *
+ * Upload `manifest.json` + the new artifact(s) the same way 5.6 was published.
+ * This script does not upload.
+ *
+ * Client fetches use `{ cache: 'no-store', redirect: 'error' }` (fail-closed).
+ * If a staging GET throws TypeError, dump the `Location` header; do not follow
+ * HTTP. Path-style `s3.amazonaws.com` is not the same host as virtual-hosted
+ * `bucket.s3.<region>.amazonaws.com`.
+ */
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const DEFAULT_UPDATE_BASE_URL =
+  'https://s3.amazonaws.com/onlykey-app/releases/latest';
+export const DEFAULT_UPDATE_MANIFEST_URL = `${DEFAULT_UPDATE_BASE_URL}/manifest.json`;
+
+export const PLATFORM_KEYS = /** @type {const} */ (['win64', 'mac64', 'linux64']);
+const SHA256_HEX = /^[a-f0-9]{64}$/;
+
+export function normalizeBaseUrl(url) {
+  return String(url || '').replace(/\/+$/, '');
+}
+
+export function normalizeManifestUrl(url) {
+  const raw = String(url || '').trim();
+  if (!raw) return DEFAULT_UPDATE_MANIFEST_URL;
+  return raw;
+}
+
+/** Trailing slash, for packaged `updateBaseUrl`. */
+export function normalizeUpdateBaseUrl(url) {
+  const base = normalizeBaseUrl(url);
+  return base ? `${base}/` : undefined;
+}
+
+/**
+ * @param {NodeJS.Platform | 'windows' | 'osx' | 'mac' | string} platform
+ * @returns {(typeof PLATFORM_KEYS)[number] | null}
+ */
+export function platformPackageKey(platform = process.platform) {
+  if (platform === 'win32' || platform === 'windows') return 'win64';
+  if (platform === 'darwin' || platform === 'osx' || platform === 'mac') return 'mac64';
+  if (platform === 'linux') return 'linux64';
+  return null;
+}
+
+export function assertSha256(value, label = 'sha256') {
+  const hex = String(value || '').trim().toLowerCase();
+  if (!SHA256_HEX.test(hex)) {
+    throw new Error(`${label} must be a 64-character lowercase hex SHA-256`);
+  }
+  return hex;
+}
+
+/** Stream the file so a ~100 MB installer is not held as one buffer. */
+export function hashFile(filePath) {
+  const size = fs.statSync(filePath).size;
+  const hash = createHash('sha256');
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const buf = Buffer.alloc(64 * 1024);
+    let n;
+    while ((n = fs.readSync(fd, buf, 0, buf.length, null)) > 0) {
+      hash.update(buf.subarray(0, n));
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+  return { sha256: hash.digest('hex'), size };
+}
+
+/**
+ * @param {string} dir `releases/update-manifest.d`
+ * @param {{
+ *   platformKey: (typeof PLATFORM_KEYS)[number],
+ *   version: string,
+ *   artifactName: string,
+ *   sha256: string,
+ *   size: number,
+ *   baseUrl?: string,
+ * }} opts
+ */
+export function writeFragment(dir, opts) {
+  const key = opts.platformKey;
+  if (!PLATFORM_KEYS.includes(key)) {
+    throw new Error(`Unknown platform key: ${key}`);
+  }
+  const sha256 = assertSha256(opts.sha256, `${key} sha256`);
+  const baseUrl = normalizeBaseUrl(opts.baseUrl || DEFAULT_UPDATE_BASE_URL);
+  const artifactName = path.basename(opts.artifactName);
+  const fragment = {
+    version: opts.version,
+    key,
+    package: {
+      url: `${baseUrl}/${artifactName}`,
+      size: opts.size,
+      sha256,
+    },
+  };
+  fs.mkdirSync(dir, { recursive: true });
+  const dest = path.join(dir, `${key}.json`);
+  fs.writeFileSync(dest, `${JSON.stringify(fragment, null, 2)}\n`);
+  return dest;
+}
+
+/**
+ * @param {string} dir
+ * @param {{ version: string, name?: string, productName?: string, now?: string }} opts
+ */
+export function mergeFragments(dir, opts) {
+  const packages = {};
+  if (fs.existsSync(dir)) {
+    const files = fs.readdirSync(dir).filter((name) => name.endsWith('.json')).sort();
+    for (const name of files) {
+      const filePath = path.join(dir, name);
+      let raw;
+      try {
+        raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      } catch {
+        throw new Error(`Update-manifest fragment ${name} is not valid JSON`);
+      }
+      if (raw.version !== opts.version) {
+        console.warn(
+          `Dropping fragment ${name}: version ${raw.version} != ${opts.version}`,
+        );
+        continue;
+      }
+      const key = raw.key;
+      if (!PLATFORM_KEYS.includes(key)) {
+        throw new Error(`Update-manifest fragment ${name} has unknown key ${key}`);
+      }
+      const sha256 = raw.package?.sha256;
+      if (!sha256) {
+        throw new Error(`Update-manifest fragment ${name} is missing sha256`);
+      }
+      const hex = assertSha256(sha256, `${name} sha256`);
+      packages[key] = {
+        url: raw.package.url,
+        size: raw.package.size,
+        sha256: hex,
+      };
+    }
+  }
+
+  return {
+    name: opts.name || 'OnlyKey',
+    productName: opts.productName || 'OnlyKey App',
+    version: opts.version,
+    publishedAt: opts.now || new Date().toISOString(),
+    packages,
+  };
+}
+
+/**
+ * Hash the OS artifact, write its fragment, merge, print the upload reminder.
+ *
+ * @param {{
+ *   artifactPath: string,
+ *   version: string,
+ *   releasesDir: string,
+ *   platform?: string,
+ *   baseUrl?: string,
+ *   name?: string,
+ *   productName?: string,
+ *   now?: string,
+ *   log?: { log: (...args: unknown[]) => void, warn?: (...args: unknown[]) => void },
+ * }} opts
+ */
+export function recordReleaseArtifact(opts) {
+  const log = opts.log || console;
+  const platform = opts.platform || process.platform;
+  const key = platformPackageKey(platform);
+  if (!key) {
+    throw new Error(`No update-manifest platform key for ${platform}`);
+  }
+  const baseUrl = opts.baseUrl || process.env.ONLYKEY_UPDATE_BASE_URL || DEFAULT_UPDATE_BASE_URL;
+  const { sha256, size } = hashFile(opts.artifactPath);
+  const fragmentDir = path.join(opts.releasesDir, 'update-manifest.d');
+  writeFragment(fragmentDir, {
+    platformKey: key,
+    version: opts.version,
+    artifactName: path.basename(opts.artifactPath),
+    sha256,
+    size,
+    baseUrl,
+  });
+  const merged = mergeFragments(fragmentDir, {
+    version: opts.version,
+    name: opts.name,
+    productName: opts.productName,
+    now: opts.now,
+  });
+  const outPath = path.join(opts.releasesDir, 'manifest.json');
+  fs.writeFileSync(outPath, `${JSON.stringify(merged, null, 2)}\n`);
+
+  const keys = Object.keys(merged.packages);
+  log.log(`Wrote update manifest: ${outPath}`);
+  log.log(`  ${key}  sha256=${sha256}  size=${size}`);
+  log.log(
+    'Upload manifest.json together with the new artifact(s) to the same S3 prefix as 5.6',
+  );
+  log.log(`  default: s3://onlykey-app/releases/latest/  (${DEFAULT_UPDATE_BASE_URL})`);
+  log.log('This build does not upload. There are no AWS credentials in this repo.');
+  if (keys.length < PLATFORM_KEYS.length) {
+    log.log(
+      `This manifest has ${keys.join(', ') || 'no platforms'}. A one-platform manifest is publishable; other OSes get missing-platform (auto-check silent; Check now shows an error).`,
+    );
+  }
+  return { outPath, manifest: merged, sha256, size, key };
+}

--- a/tests/desktop/update-manifest.static.test.mjs
+++ b/tests/desktop/update-manifest.static.test.mjs
@@ -8,8 +8,11 @@ import { buildProductionPackageJson } from '../../scripts/release.mjs';
 import {
   DEFAULT_UPDATE_BASE_URL,
   DEFAULT_UPDATE_MANIFEST_URL,
+  assertSignedArtifact,
   hashFile,
+  inferPlatformFromArtifact,
   mergeFragments,
+  parseUpdateManifestArgs,
   platformPackageKey,
   recordReleaseArtifact,
   writeFragment,
@@ -34,14 +37,32 @@ const sourcePkg = {
 };
 
 describe('release.mjs wiring', () => {
-  it('records the hashed artifact after a successful OS package', () => {
+  it('does not hash the unsigned installer; points at update-manifest after signing', () => {
     const src = fs.readFileSync(
       path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../scripts/release.mjs'),
       'utf8',
     );
-    expect(src).toContain('recordReleaseArtifact');
+    expect(src).not.toContain('recordReleaseArtifact');
+    expect(src).toContain('npm run update-manifest');
     expect(src).toContain('ONLYKEY_UPDATE_MANIFEST_URL');
     expect(src).toContain('ONLYKEY_UPDATE_BASE_URL');
+  });
+});
+
+describe('inferPlatformFromArtifact / CLI args', () => {
+  it('maps installer extensions to node platforms', () => {
+    expect(inferPlatformFromArtifact('OnlyKey_5.7.0.exe')).toBe('win32');
+    expect(inferPlatformFromArtifact('OnlyKey_5.7.0.dmg')).toBe('darwin');
+    expect(inferPlatformFromArtifact('OnlyKey_5.7.0_amd64.deb')).toBe('linux');
+    expect(inferPlatformFromArtifact('OnlyKey.bin')).toBeNull();
+  });
+
+  it('parses --artifact and --allow-unsigned', () => {
+    expect(parseUpdateManifestArgs(['--artifact', 'a.exe', '--allow-unsigned'])).toMatchObject({
+      artifact: 'a.exe',
+      allowUnsigned: true,
+    });
+    expect(() => parseUpdateManifestArgs(['--nope'])).toThrow(/Unknown argument/);
   });
 });
 
@@ -199,6 +220,31 @@ describe('hashFile / writeFragment / mergeFragments', () => {
   });
 });
 
+describe('assertSignedArtifact', () => {
+  it('refuses a Windows installer Authenticode reports as NotSigned', () => {
+    expect(() =>
+      assertSignedArtifact('C:\\signed\\OnlyKey.exe', 'win32', {
+        inspectAuthenticode: () => ({ status: 'NotSigned' }),
+      }),
+    ).toThrow(/unsigned Windows installer/i);
+  });
+
+  it('accepts Valid Authenticode', () => {
+    expect(
+      assertSignedArtifact('C:\\signed\\OnlyKey.exe', 'win32', {
+        inspectAuthenticode: () => ({ status: 'Valid', signer: 'CN=CryptoTrust' }),
+      }),
+    ).toMatchObject({ status: 'Valid' });
+  });
+
+  it('skips the check when requireSigned is false', () => {
+    expect(assertSignedArtifact('unsigned.exe', 'win32', { requireSigned: false })).toEqual({
+      status: 'skipped',
+      signer: '',
+    });
+  });
+});
+
 describe('recordReleaseArtifact', () => {
   it('writes fragment + merged manifest and notes a one-platform file', () => {
     const dir = makeDir();
@@ -214,6 +260,7 @@ describe('recordReleaseArtifact', () => {
         releasesDir: dir,
         baseUrl: DEFAULT_UPDATE_BASE_URL,
         now: '2026-09-11T00:00:00.000Z',
+        requireSigned: false,
         log: { log: (...args) => lines.push(args.join(' ')) },
       });
       expect(result.key).toBe('win64');
@@ -223,6 +270,38 @@ describe('recordReleaseArtifact', () => {
       expect(manifest.packages.win64.sha256).toBe(shaOf(body));
       expect(lines.join('\n')).toMatch(/one-platform manifest is publishable/i);
       expect(lines.join('\n')).toMatch(/does not upload/i);
+      expect(lines.join('\n')).toMatch(/signed file/i);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('hashes a file Authenticode reports Valid and refuses NotSigned', () => {
+    const dir = makeDir();
+    try {
+      const artifact = path.join(dir, 'OnlyKey_5.7.0.exe');
+      fs.writeFileSync(artifact, 'signed-bytes');
+      const ok = recordReleaseArtifact({
+        artifactPath: artifact,
+        version: '5.7.0',
+        platform: 'win32',
+        releasesDir: dir,
+        requireSigned: true,
+        inspectAuthenticode: () => ({ status: 'Valid', signer: 'CN=CryptoTrust' }),
+        log: { log: () => {} },
+      });
+      expect(ok.signature).toMatchObject({ status: 'Valid' });
+      expect(() =>
+        recordReleaseArtifact({
+          artifactPath: artifact,
+          version: '5.7.0',
+          platform: 'win32',
+          releasesDir: dir,
+          requireSigned: true,
+          inspectAuthenticode: () => ({ status: 'NotSigned' }),
+          log: { log: () => {} },
+        }),
+      ).toThrow(/unsigned Windows installer/i);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/desktop/update-manifest.static.test.mjs
+++ b/tests/desktop/update-manifest.static.test.mjs
@@ -1,0 +1,273 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildProductionPackageJson } from '../../scripts/release.mjs';
+import {
+  DEFAULT_UPDATE_BASE_URL,
+  DEFAULT_UPDATE_MANIFEST_URL,
+  hashFile,
+  mergeFragments,
+  platformPackageKey,
+  recordReleaseArtifact,
+  writeFragment,
+} from '../../scripts/update-manifest.mjs';
+
+function makeDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ok-upd-man-'));
+}
+
+function shaOf(buf) {
+  return createHash('sha256').update(buf).digest('hex');
+}
+
+const sourcePkg = {
+  name: 'OnlyKey',
+  productName: 'OnlyKey App',
+  version: '5.7.0',
+  version_name: '5.7.0',
+  description: 'Setup and configure OnlyKey',
+  'chromium-args': '--disable-background-timer-throttling',
+  window: { inject_js_start: 'desktopInject.js' },
+};
+
+describe('release.mjs wiring', () => {
+  it('records the hashed artifact after a successful OS package', () => {
+    const src = fs.readFileSync(
+      path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../scripts/release.mjs'),
+      'utf8',
+    );
+    expect(src).toContain('recordReleaseArtifact');
+    expect(src).toContain('ONLYKEY_UPDATE_MANIFEST_URL');
+    expect(src).toContain('ONLYKEY_UPDATE_BASE_URL');
+  });
+});
+
+describe('platformPackageKey', () => {
+  it('maps node and release platform names to win64/mac64/linux64', () => {
+    expect(platformPackageKey('win32')).toBe('win64');
+    expect(platformPackageKey('windows')).toBe('win64');
+    expect(platformPackageKey('darwin')).toBe('mac64');
+    expect(platformPackageKey('osx')).toBe('mac64');
+    expect(platformPackageKey('linux')).toBe('linux64');
+    expect(platformPackageKey('aix')).toBeNull();
+  });
+});
+
+describe('hashFile / writeFragment / mergeFragments', () => {
+  /** @type {string[]} */
+  const dirs = [];
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('hashes a fixture buffer into sha256 + size', () => {
+    const dir = makeDir();
+    dirs.push(dir);
+    const body = Buffer.from('onlykey-update-bytes');
+    const file = path.join(dir, 'OnlyKey_5.7.0.exe');
+    fs.writeFileSync(file, body);
+    expect(hashFile(file)).toEqual({ sha256: shaOf(body), size: body.byteLength });
+  });
+
+  it('writes a fragment with sha256, size, and a URL under the base', () => {
+    const dir = makeDir();
+    dirs.push(dir);
+    const body = Buffer.from('win-artifact');
+    const dest = writeFragment(dir, {
+      platformKey: 'win64',
+      version: '5.7.0',
+      artifactName: 'OnlyKey_5.7.0.exe',
+      sha256: shaOf(body),
+      size: body.byteLength,
+      baseUrl: DEFAULT_UPDATE_BASE_URL,
+    });
+    const fragment = JSON.parse(fs.readFileSync(dest, 'utf8'));
+    expect(fragment).toEqual({
+      version: '5.7.0',
+      key: 'win64',
+      package: {
+        url: `${DEFAULT_UPDATE_BASE_URL}/OnlyKey_5.7.0.exe`,
+        size: body.byteLength,
+        sha256: shaOf(body),
+      },
+    });
+  });
+
+  it('honors ONLYKEY_UPDATE_BASE_URL for package URLs', () => {
+    const dir = makeDir();
+    dirs.push(dir);
+    const sha = shaOf(Buffer.from('x'));
+    writeFragment(dir, {
+      platformKey: 'linux64',
+      version: '5.7.0',
+      artifactName: 'OnlyKey_5.7.0_amd64.deb',
+      sha256: sha,
+      size: 1,
+      baseUrl: 'https://s3.amazonaws.com/onlykey-app/releases/5.7-staging/',
+    });
+    const fragment = JSON.parse(fs.readFileSync(path.join(dir, 'linux64.json'), 'utf8'));
+    expect(fragment.package.url).toBe(
+      'https://s3.amazonaws.com/onlykey-app/releases/5.7-staging/OnlyKey_5.7.0_amd64.deb',
+    );
+  });
+
+  it('merges win64+linux64 of the same version and omits mac64', () => {
+    const dir = makeDir();
+    dirs.push(dir);
+    const win = Buffer.from('win');
+    const lin = Buffer.from('linux');
+    writeFragment(dir, {
+      platformKey: 'win64',
+      version: '5.7.0',
+      artifactName: 'OnlyKey_5.7.0.exe',
+      sha256: shaOf(win),
+      size: win.byteLength,
+      baseUrl: DEFAULT_UPDATE_BASE_URL,
+    });
+    writeFragment(dir, {
+      platformKey: 'linux64',
+      version: '5.7.0',
+      artifactName: 'OnlyKey_5.7.0_amd64.deb',
+      sha256: shaOf(lin),
+      size: lin.byteLength,
+      baseUrl: DEFAULT_UPDATE_BASE_URL,
+    });
+    const merged = mergeFragments(dir, { version: '5.7.0', now: '2026-09-11T00:00:00.000Z' });
+    expect(Object.keys(merged.packages).sort()).toEqual(['linux64', 'win64']);
+    expect(merged.packages.mac64).toBeUndefined();
+    expect(merged.packages.win64.sha256).toBe(shaOf(win));
+    expect(merged.packages.linux64.sha256).toBe(shaOf(lin));
+    expect(merged.version).toBe('5.7.0');
+  });
+
+  it('refuses a fragment missing sha256', () => {
+    const dir = makeDir();
+    dirs.push(dir);
+    fs.writeFileSync(
+      path.join(dir, 'win64.json'),
+      `${JSON.stringify({
+        version: '5.7.0',
+        key: 'win64',
+        package: { url: `${DEFAULT_UPDATE_BASE_URL}/OnlyKey_5.7.0.exe`, size: 1 },
+      })}\n`,
+    );
+    expect(() => mergeFragments(dir, { version: '5.7.0' })).toThrow(/missing sha256/);
+  });
+
+  it('refuses a fragment whose sha256 is not 64 hex chars', () => {
+    const dir = makeDir();
+    dirs.push(dir);
+    expect(() =>
+      writeFragment(dir, {
+        platformKey: 'win64',
+        version: '5.7.0',
+        artifactName: 'OnlyKey_5.7.0.exe',
+        sha256: 'not-a-hash',
+        size: 1,
+        baseUrl: DEFAULT_UPDATE_BASE_URL,
+      }),
+    ).toThrow(/64-character/);
+  });
+
+  it('drops a fragment whose version does not match the release', () => {
+    const dir = makeDir();
+    dirs.push(dir);
+    const current = Buffer.from('now');
+    const stale = Buffer.from('old');
+    writeFragment(dir, {
+      platformKey: 'win64',
+      version: '5.7.0',
+      artifactName: 'OnlyKey_5.7.0.exe',
+      sha256: shaOf(current),
+      size: current.byteLength,
+      baseUrl: DEFAULT_UPDATE_BASE_URL,
+    });
+    writeFragment(dir, {
+      platformKey: 'mac64',
+      version: '5.6.0',
+      artifactName: 'OnlyKey_5.6.0.dmg',
+      sha256: shaOf(stale),
+      size: stale.byteLength,
+      baseUrl: DEFAULT_UPDATE_BASE_URL,
+    });
+    const merged = mergeFragments(dir, { version: '5.7.0', now: '2026-09-11T00:00:00.000Z' });
+    expect(merged.packages.win64).toBeTruthy();
+    expect(merged.packages.mac64).toBeUndefined();
+  });
+});
+
+describe('recordReleaseArtifact', () => {
+  it('writes fragment + merged manifest and notes a one-platform file', () => {
+    const dir = makeDir();
+    try {
+      const body = Buffer.from('installer');
+      const artifact = path.join(dir, 'OnlyKey_5.7.0.exe');
+      fs.writeFileSync(artifact, body);
+      const lines = [];
+      const result = recordReleaseArtifact({
+        artifactPath: artifact,
+        version: '5.7.0',
+        platform: 'win32',
+        releasesDir: dir,
+        baseUrl: DEFAULT_UPDATE_BASE_URL,
+        now: '2026-09-11T00:00:00.000Z',
+        log: { log: (...args) => lines.push(args.join(' ')) },
+      });
+      expect(result.key).toBe('win64');
+      expect(result.sha256).toBe(shaOf(body));
+      const manifest = JSON.parse(fs.readFileSync(path.join(dir, 'manifest.json'), 'utf8'));
+      expect(manifest.packages.win64.url).toBe(`${DEFAULT_UPDATE_BASE_URL}/OnlyKey_5.7.0.exe`);
+      expect(manifest.packages.win64.sha256).toBe(shaOf(body));
+      expect(lines.join('\n')).toMatch(/one-platform manifest is publishable/i);
+      expect(lines.join('\n')).toMatch(/does not upload/i);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('buildProductionPackageJson', () => {
+  const envKeys = ['ONLYKEY_UPDATE_MANIFEST_URL', 'ONLYKEY_UPDATE_BASE_URL'];
+  /** @type {Record<string, string | undefined>} */
+  const previous = {};
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (previous[key] === undefined) delete process.env[key];
+      else process.env[key] = previous[key];
+      delete previous[key];
+    }
+  });
+
+  function stashEnv() {
+    for (const key of envKeys) {
+      previous[key] = process.env[key];
+      delete process.env[key];
+    }
+  }
+
+  it('defaults to repo manifest.json when env is unset', () => {
+    stashEnv();
+    const pkg = buildProductionPackageJson(sourcePkg);
+    expect(pkg.manifestUrl).toBe(DEFAULT_UPDATE_MANIFEST_URL);
+    expect(pkg.updateBaseUrl).toBeUndefined();
+  });
+
+  it('uses ONLYKEY_UPDATE_MANIFEST_URL over repo manifest.json', () => {
+    stashEnv();
+    process.env.ONLYKEY_UPDATE_MANIFEST_URL =
+      'https://s3.amazonaws.com/onlykey-app/releases/5.7-staging/manifest.json';
+    process.env.ONLYKEY_UPDATE_BASE_URL =
+      'https://s3.amazonaws.com/onlykey-app/releases/5.7-staging';
+    const pkg = buildProductionPackageJson(sourcePkg);
+    expect(pkg.manifestUrl).toBe(
+      'https://s3.amazonaws.com/onlykey-app/releases/5.7-staging/manifest.json',
+    );
+    expect(pkg.updateBaseUrl).toBe(
+      'https://s3.amazonaws.com/onlykey-app/releases/5.7-staging/',
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
             'src/**/*.{test,spec}.{ts,tsx}',
             'src/**/*.ui.test.{ts,tsx}',
             'tests/desktop/release-packaging.static.test.mjs',
+            'tests/desktop/update-manifest.static.test.mjs',
           ],
           exclude: ['node_modules', 'dist'],
           env: {


### PR DESCRIPTION
After each OS artifact, hash it, write releases/update-manifest.d/<key>.json, and merge same-version fragments into releases/manifest.json. Packaged package.json honors ONLYKEY_UPDATE_MANIFEST_URL and ONLYKEY_UPDATE_BASE_URL. Does not upload to S3.